### PR TITLE
Enable alien-token-init and alien-token-info scripts

### DIFF
--- a/bin/alien-token-info
+++ b/bin/alien-token-info
@@ -1,0 +1,2 @@
+#!/bin/bash
+alien.py token-info $@

--- a/bin/alien-token-init
+++ b/bin/alien-token-init
@@ -1,2 +1,3 @@
 #!/bin/bash
-echo "WARNING: This is a no-op call. The alien-token-init isn't needed for JAliEn"
+echo "INFO: jalien clients automatically create tokens, running alien-token-init is no longer required"
+alien.py token-init $@

--- a/xjalienfs/alien.py
+++ b/xjalienfs/alien.py
@@ -1545,6 +1545,7 @@ async def ProcessInput(wb: websockets.client.WebSocketClientProtocol, cmd_string
             wb = await token_regen(wb, args)
 
             if os.path.exists(tokencert) and os.path.exists(tokenkey):
+                CertInfo(tokencert)
                 AlienSessionInfo['exitcode'] = int(0)
             else:
                 AlienSessionInfo['exitcode'] = int(1)


### PR DESCRIPTION
Actually refresh token on `alien-token-init` instead of just printing the warning.