### PR TITLE
Fix security level for 80bit server

### DIFF
--- a/xjalienfs/alien.py
+++ b/xjalienfs/alien.py
@@ -1336,6 +1336,7 @@ def create_ssl_context(use_usercert: bool = False) -> ssl.SSLContext:
         AlienSessionInfo['use_usercert'] = False
 
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS)
+    ctx.set_ciphers('DEFAULT@SECLEVEL=1')  # Server uses only 80bit (sigh)
     ctx.options |= ssl.OP_NO_SSLv3
     ctx.verify_mode = ssl.CERT_REQUIRED  # CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
     ctx.check_hostname = False


### PR DESCRIPTION
This PR fixes the problem when the client machine default SSL security level is set to 2 (Debian, Ubuntu, and similar).   This is done by setting the Cipher string to `DEFAULT@SECLEVEL=1` in the client directly.   Similar fix should be applied to `jalien-ROOT`. 