### PR TITLE
Fix setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,13 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 alibuild_requirements = [
-        'gnureadline',
+        'readline',
         'async-stagger',
         'websockets',
         'pyOpenSSL',
     ]
 
-standard_requirements = alibuild_requirements + ["pyxrootd"]
+standard_requirements = alibuild_requirements + ["xrootd"]
 
 selected_requirements = standard_requirements if "ALIBUILD" not in os.environ.keys() else alibuild_requirements
 

--- a/xjalienfs/alien.py
+++ b/xjalienfs/alien.py
@@ -1336,6 +1336,7 @@ def create_ssl_context(use_usercert: bool = False) -> ssl.SSLContext:
         AlienSessionInfo['use_usercert'] = False
 
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS)
+    ctx.set_ciphers('DEFAULT@SECLEVEL=1')  # Server uses only 80bit (sigh)
     ctx.options |= ssl.OP_NO_SSLv3
     ctx.verify_mode = ssl.CERT_REQUIRED  # CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
     ctx.check_hostname = False


### PR DESCRIPTION
This PR removed the Python package `gnureadline` as a dependency.   It does _not_ disable `gnureadline` at run-time.  Also, XRootD dependency renamed from `pyxrootd` to `xrootd`. 

The rational: `gnureadline` is deprecated on all platforms but MacOSX.  Instead, one should use the default Python `readline` interface.  Thus, the package must not _depend_ on `gnureadline` but can still use it if present on the target system.   Dependencies are supposed to stipulate _minimal_ requirements - not _nice to have_ features. 

The Python interface of XRootD provides `xrootd` _not_ `pyxrootd`. 