### PR TITLE
Console scripts

### DIFF
--- a/bin/alien-token-info
+++ b/bin/alien-token-info
@@ -1,2 +1,0 @@
-#!/bin/bash
-alien.py token-info $@

--- a/bin/alien-token-init
+++ b/bin/alien-token-init
@@ -1,3 +1,0 @@
-#!/bin/bash
-echo "INFO: jalien clients automatically create tokens, running alien-token-init is no longer required"
-alien.py token-init $@

--- a/bin/alien_cmd
+++ b/bin/alien_cmd
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py "${@}"

--- a/bin/alien_cp
+++ b/bin/alien_cp
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py cp "${@}"

--- a/bin/alien_find
+++ b/bin/alien_find
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py find "${@}"

--- a/bin/alien_guid2lfn
+++ b/bin/alien_guid2lfn
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py guid2lfn "${@}"

--- a/bin/alien_lfn2guid
+++ b/bin/alien_lfn2guid
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py lfn2guid "${@}"

--- a/bin/alien_ls
+++ b/bin/alien_ls
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py ls "${@}"

--- a/bin/alien_mirror
+++ b/bin/alien_mirror
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py mirror "${@}"

--- a/bin/alien_mkdir
+++ b/bin/alien_mkdir
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py mkdir "${@}"

--- a/bin/alien_mv
+++ b/bin/alien_mv
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py mv "${@}"

--- a/bin/alien_ps
+++ b/bin/alien_ps
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py ps "${@}"

--- a/bin/alien_rm
+++ b/bin/alien_rm
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py rm "${@}"

--- a/bin/alien_rmdir
+++ b/bin/alien_rmdir
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py rmdir "${@}"

--- a/bin/alien_stat
+++ b/bin/alien_stat
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py stat "${@}"

--- a/bin/alien_submit
+++ b/bin/alien_submit
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec alien.py submit "${@}"

--- a/bin/alien_whereis
+++ b/bin/alien_whereis
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-ARGS="$(echo ${@}| sed 's/ -g//' )" ## if -g was used, remove it as we will detect later if it is required
-GUID_PATTERN='(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}'
-CMD="alien.py whereis"
-[[ ${ARGS} =~ ${GUID_PATTERN} ]] && CMD="${CMD} -g"
-exec ${CMD} ${ARGS}

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,30 @@ setuptools.setup(
         "License :: OSI Approved :: BSD 3-Clause License",
         "Operating System :: OS Independent",
     ],
+    scripts = [
+        'bin/alien_pfn',
+    ],
+    entry_points = {
+        'console_scripts': [
+            'aliensh = xjalienfs.alien:main',
+            'alien_cmd = xjalienfs.alien:main',
+            'alien_cp = xjalienfs.alien:cmd_cp',
+            'alien_find = xjalienfs.alien:cmd_find',
+            'alien_guid2lfn = xjalienfs.alien:cmd_guid2lfn',
+            'alien_lfn2guid = xjalienfs.alien:cmd_lfn2guid',
+            'alien_ls = xjalienfs.alien:cmd_ls',
+            'alien_mirror = xjalienfs.alien:cmd_mirror',
+            'alien_mkdir = xjalienfs.alien:cmd_mkdir',
+            'alien_mv = xjalienfs.alien:cmd_mv',
+            'alien_ps = xjalienfs.alien:cmd_ps',
+            'alien_rm = xjalienfs.alien:cmd_rm',
+            'alien_rmdir = xjalienfs.alien:cmd_rmdir',
+            'alien_stat = xjalienfs.alien:cmd_stat',
+            'alien_submit = xjalienfs.alien:cmd_submit',
+            'alien-token-info = xjalienfs.alien:cmd_token_info',
+            'alien-token-init = xjalienfs.alien:cmd_token_init',
+            'alien_whereis = xjalienfs.alien:cmd_whereis',
+        ]
+    }
 )
 

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,13 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 alibuild_requirements = [
-        'gnureadline',
+        'readline',
         'async-stagger',
         'websockets',
         'pyOpenSSL',
     ]
 
-standard_requirements = alibuild_requirements + ["pyxrootd"]
+standard_requirements = alibuild_requirements + ["xrootd"]
 
 selected_requirements = standard_requirements if "ALIBUILD" not in os.environ.keys() else alibuild_requirements
 

--- a/xjalienfs/alien.py
+++ b/xjalienfs/alien.py
@@ -1336,6 +1336,7 @@ def create_ssl_context(use_usercert: bool = False) -> ssl.SSLContext:
         AlienSessionInfo['use_usercert'] = False
 
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS)
+    ctx.set_ciphers('DEFAULT@SECLEVEL=1')  # Server uses only 80bit (sigh)
     ctx.options |= ssl.OP_NO_SSLv3
     ctx.verify_mode = ssl.CERT_REQUIRED  # CERT_NONE, CERT_OPTIONAL, CERT_REQUIRED
     ctx.check_hostname = False

--- a/xjalienfs/alien.py
+++ b/xjalienfs/alien.py
@@ -1968,6 +1968,68 @@ def main():
         sys.exit(1)
     os._exit(int(AlienSessionInfo['exitcode']))
 
+def _cmd(what):
+    sys.argv = [sys.argv[0]] + [what] + sys.argv[1:]
+    main()
+
+def cmd_cp():
+    _cmd('cp')
+
+def cmd_find():
+    _cmd('find')
+
+def cmd_guid2lfn():
+    _cmd('guid2lfn')
+
+def cmd_lfn2guid():
+    _cmd('lfn2guid')
+
+def cmd_ls():
+    _cmd('ls')
+
+def cmd_mirror():
+    _cmd('mirror')
+
+def cmd_mkdir():
+    _cmd('mkdir')
+
+def cmd_mv():
+    _cmd('mv')
+
+def cmd_ps():
+    _cmd('ps')
+
+def cmd_rm():
+    _cmd('rm')
+
+def cmd_rmdir():
+    _cmd('rmdir')
+
+def cmd_stat():
+    _cmd('stat')
+
+def cmd_submit():
+    _cmd('submit')
+
+def cmd_token_info():
+    _cmd('token-info')
+
+def cmd_token_init():
+    print('INFO: JAliEn client automatically creates tokens, '
+          'alien-token-init is deprecated')
+    _cmd('token-init')
+
+def cmd_whereis():
+    if '-g' in sys.argv:
+        sys.argv.remove('-g')
+
+    p = re.compile(r'{?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}}?')
+    for a in sys.argv:
+        if p.match(a):
+            sys.argv = sys.argv[0] + ['-g'] + sys.argv[1:]
+            break
+    
+    _cmd('whereis')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
In this PR we create the using facing scripts (such as `alien_cp`) through the [`setuptools`](https://setuptools.readthedocs.io/en/latest/setuptools.html) [_console-script_](https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation) mechanism.   That is, the shell script present in `bin/` of the repository are removed in favour of defining the _entry-points_ in `setup.py`.   

So what happens: When installing the package (via `pip`, directly via `setup.py` - f.ex. in develop mode), `setuptools` writes small wrappers to the target installation `bin` directory (e.g., `/usr/local/bin`, `~/.local/bin`) which imports the appropriate module or package and executes the named function from that module.  

As an example 

    entry_points = {
        'console_scripts': [
            'alien_cp = xjalienfs.alien:cmd_cp',
         }
    }

will generate the _console-script_ `alien_cp` which essentially does 

    import xjalienfs.alien 
    xjalienfs.alien.cmp_cp()

To this end, we add a few (small) functions to `alien.py`  - essentially doing, for example 

    def do_cp():
        sys.argv = sys.argv[:1] + ['cp'] + sys.argv[1:]
        main()

The benefits of using `setuptools` entry points like this is that it can correctly take care of platform idiosyncrasies, set-up proper load paths, and so on. 

Remember, one can always install a package in _developer_ mode (i.e., no scripts are actually copied to destination - instead a "pointer" is created at the destination that points back to the working directory.  In this way, any changes made to the source is immediately reflected in the the "installation") by 

    python setup.py develop --user 

The only script _not_ rewritten like this is `alice_pfn` which remains a shell script that calls the entry point `alien_which`. 
       